### PR TITLE
Update copy-rootfs-ssd.sh

### DIFF
--- a/copy-rootfs-ssd.sh
+++ b/copy-rootfs-ssd.sh
@@ -2,6 +2,6 @@
 # Mount the SSD as /mnt
 sudo mount /dev/nvme0n1p1 /mnt
 # Copy over the rootfs from the SD card to the SSD
-sudo rsync -axHAWX --numeric-ids --info=progress2 --exclude={"/dev/","/proc/","/sys/","/tmp/","/run/","/mnt/","/media/*","/lost+found"} / /mnt
+sudo rsync -axHAWX --numeric-ids --info=progress2 --exclude={"/dev/","/proc/","/sys/","/tmp/","/run/","/mnt/","/media/*","/lost+found","/boot"} / /mnt
 # We want to keep the SSD mounted for further operations
 # So we do not unmount the SSD


### PR DESCRIPTION
rootOnNVMe presumes the boot process begins on the emmc for it to work properly. I’ll make a pull request to the github project.

Long story short, Jetpack 4.5.1 /boot folder on NVMe isn’t used since boot flow has progressed past any need for it., Jetpack 4.6 /boot folder on NVMe breaks rootOnNVMe method, even if emmc is copied to the NVMe device.

Solution: Exclude boot folder from rsync copy of emmc → nvme found in the copy-rootfs-ssd.sh script.

See: https://forums.developer.nvidia.com/t/jetpack-4-6-xserver-does-not-start/186499