### PR TITLE
Add example for SATA3 SSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # rootOnNVMe
+
 Switch the rootfs to a NVMe SSD on the Jetson Xavier NX and Jetson AGX Xavier
 
 These scripts install a service which runs at startup to point the rootfs to a SSD installed on /dev/nvme0 (the M.2 Key M slot).
@@ -8,11 +9,13 @@ This is taken from the NVIDIA Jetson AGX Xavier forum https://forums.developer.n
 This procedure should be done on a fresh install of the SD card using JetPack 4.3+. Install the SSD into the M.2 Key M slot of the Jetson, and format it gpt, ext4, and setup a partition (p1). The AGX Xavier uses eMMC, the Xavier NX uses a SD card in the boot sequence.
 
 Next, copy the rootfs of the eMMC/SD card to the SSD
+
 ```
 $ ./copy-rootfs-ssd.sh
 ```
 
 Then, setup the service. This will copy the .service file to the correct location, and install a startup script to set the rootfs to the SSD.
+
 ```
 $ ./setup-service.sh
 ```
@@ -20,16 +23,23 @@ $ ./setup-service.sh
 After setting up the service, reboot for the changes to take effect.
 
 ### Boot Notes
+
 These script changes the rootfs to the SSD after the kernel image is loaded from the eMMC/SD card. For the Xavier NX, you will still need to have the SD card installed for booting. As of this writing, the default configuration of the Jetson NX does not allow direct booting from the NVMe.
 
 ### Upgrading
+
 Once this service is installed, the rootfs will be on the SSD. If you upgrade to a newer version of L4T using OTA updates (using the NVIDIA .deb repository), you will need to also apply those changes to the SD card that you are booting from.
 
-Typically this involves copying the /boot* directory and /lib/modules/\<kernel name\>/ from the SSD to the SD card. If they are different, then modules load will be 'tainted', that is, the modules version will not match the kernel version.
-
+Typically this involves copying the /boot\* directory and /lib/modules/\<kernel name\>/ from the SSD to the SD card. If they are different, then modules load will be 'tainted', that is, the modules version will not match the kernel version.
 
 ## Notes
-* Initial Release, May 2020
-* JetPack 4.4 DP
-* Tested on Jetson Xavier NX
 
+- Initial Release, May 2020
+- JetPack 4.4 DP
+- Tested on Jetson Xavier NX
+
+- Second Release, October 2021
+- Ubuntu 18.04.6
+- JetPack 4.6
+- Samsung SSD (SATA3)
+- Tested on Jetson TX2

--- a/copy-rootfs-ssd.sh
+++ b/copy-rootfs-ssd.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
+# Check your device name
+# NVME SSD : /dev/nvme0n1p1
+# SATA3 SSD : /dev/sda1
+
 # Mount the SSD as /mnt
-sudo mount /dev/nvme0n1p1 /mnt
+# sudo mount /dev/"your device name" /mnt
+sudo mount /dev/sda1 /mnt
 # Copy over the rootfs from the SD card to the SSD
 sudo rsync -axHAWX --numeric-ids --info=progress2 --exclude={"/dev/","/proc/","/sys/","/tmp/","/run/","/mnt/","/media/*","/lost+found"} / /mnt
 # We want to keep the SSD mounted for further operations

--- a/data/setssdroot.service
+++ b/data/setssdroot.service
@@ -1,11 +1,11 @@
 [Unit]
-Description=Change rootfs to SSD in M.2 key M slot (nvme0n1p1)
+Description=Change rootfs to SSD in SATA3 slot (sda1)
 DefaultDependencies=no
 Conflicts=shutdown.target
 After=systemd-remount-fs.service
 Before=local-fs-pre.target local-fs.target shutdown.target
 Wants=local-fs-pre.target
-ConditionPathExists=/dev/nvme0n1p1
+ConditionPathExists=/dev/sda1
 ConditionPathExists=/etc/setssdroot.conf
 ConditionVirtualization=!container
 [Service]

--- a/data/setssdroot.sh
+++ b/data/setssdroot.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
-# Runs at startup, switches rootfs to the SSD on nvme0 (M.2 Key M slot)
-NVME_DRIVE="/dev/nvme0n1p1"
+# Runs at startup, switches rootfs to the SSD on sda1 (SATA3 slot)
+# If your SSD is NVME, Change "/dev/sda1" to "/dev/nvme0n1p1"
+# Check your device name
+# NVME SSD : /dev/nvme0n1p1
+# SATA3 SSD : /dev/sda1
+NVME_DRIVE="/dev/sda1"
 CHROOT_PATH="/nvmeroot"
 
 INITBIN=/lib/systemd/systemd


### PR DESCRIPTION
hi jetsonhacks

I'd modified your code a little for my Jetson TX2 with SATA3 SSD and It works well ! :)

I hope you merge my branch for someone looking for SATA3 version of rootOnNVMe.

Thanks.

*Tested environment
Ubuntu 18.04.6
JetPack 4.6
Samsung SSD (SATA3)
Jetson TX2