### PR TITLE
Dynamic usecase

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This is taken from the NVIDIA Jetson AGX Xavier forum https://forums.developer.n
 
 This procedure should be done on a fresh install of the SD card using JetPack 4.3+. Install the SSD into the M.2 Key M slot of the Jetson, and format it gpt, ext4, and setup a partition (p1). The AGX Xavier uses eMMC, the Xavier NX uses a SD card in the boot sequence.
 
-Next, copy the rootfs of the eMMC/SD card to the SSD
+Next, copy the rootfs of the eMMC/SD card to the SSD (nvme/usb)
 ```
-$ ./copy-rootfs-ssd.sh
+$ ./copy-rootfs-ssd.sh <usb|nvme>
 ```
 
 Then, setup the service. This will copy the .service file to the correct location, and install a startup script to set the rootfs to the SSD.

--- a/copy-rootfs-ssd.sh
+++ b/copy-rootfs-ssd.sh
@@ -1,7 +1,25 @@
 #!/bin/bash
-# Mount the SSD as /mnt
-sudo mount /dev/nvme0n1p1 /mnt
-# Copy over the rootfs from the SD card to the SSD
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <nvme|usb>"
+  exit 1
+fi
+
+device_type=$1
+device_path=""
+
+if [ "$device_type" == "nvme" ]; then
+  device_path="/dev/nvme0n1p1"
+elif [ "$device_type" == "usb" ]; then
+  device_path="/dev/sda1"
+else
+  echo "Invalid device type. Supported types: nvme, usb"
+  exit 1
+fi
+
+# Mount the device as /mnt
+sudo mount $device_path /mnt
+# Copy over the rootfs from the SD card to the device
 sudo rsync -axHAWX --numeric-ids --info=progress2 --exclude={"/dev/","/proc/","/sys/","/tmp/","/run/","/mnt/","/media/*","/lost+found"} / /mnt
-# We want to keep the SSD mounted for further operations
-# So we do not unmount the SSD
+# We want to keep the device mounted for further operations
+# So we do not unmount the device


### PR DESCRIPTION
Hi, 

Added usb / nvme capability to also support booting from USB  (used it for both cases successfully). 
usecase is now:

`./copy-rootfs-ssd.sh <usb|nvme>`